### PR TITLE
change login names to email address rather than uid

### DIFF
--- a/lib/Hooks/UserHooks.php
+++ b/lib/Hooks/UserHooks.php
@@ -86,13 +86,13 @@ class UserHooks {
 			$account->setInboundHost($this->config->getImapHost());
 			$account->setInboundPort($this->config->getImapPort());
 			$account->setInboundSslMode($this->config->getImapSslMode());
-			$account->setInboundUser($uid);
+			$account->setInboundUser($email);
 			$account->setInboundPassword($this->encrypt($password));
 
 			$account->setOutboundHost($this->config->getSmtpHost());
 			$account->setOutboundPort($this->config->getSmtpPort());
 			$account->setOutboundSslMode($this->config->getSmtpSslMode());
-			$account->setOutboundUser($uid);
+			$account->setOutboundUser($email);
 			$account->setOutboundPassword($this->encrypt($password));
 
 			$this->accountService->save($account);


### PR DESCRIPTION
My IMAP and SMTP servers expect email address style user names, and from what I see elsewhere I would suspect these default settings to be more robust across different setups.